### PR TITLE
Implement ReportLoadResult/ReportCaseResult/Close interface for SDK

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -1,0 +1,27 @@
+name: Go
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Run Go Tests
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.18'
+
+    - name: Check out code
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Run tests
+      run: go test -v ./...

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -10,15 +10,18 @@ jobs:
   test:
     name: Run Go Tests
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['1.18', '1.19', '1.20', '1.21', '1.22']
 
     steps:
-    - name: Set up Go
-      uses: actions/setup-go@v2
+    - name: Set up Go ${{ matrix.python-version }}
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.18'
+        go-version: ${{ matrix.python-version }}
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Get dependencies
       run: go mod download

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -23,5 +23,5 @@ jobs:
     - name: Get dependencies
       run: go mod download
 
-    - name: Run tests
-      run: go test -v ./...
+    - name: Run tests and check coverage
+      run: ./scripts/coverage.sh

--- a/api/api.go
+++ b/api/api.go
@@ -1,0 +1,9 @@
+package api
+
+import "github.com/OpenTestSolar/testtool-sdk-golang/model"
+
+type Reporter interface {
+	ReportLoadResult(loadResult *model.LoadResult) error
+	ReportCaseResult(caseResult *model.TestResult) error
+	Close() error
+}

--- a/client/client.go
+++ b/client/client.go
@@ -1,0 +1,102 @@
+package client
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+
+	"github.com/OpenTestSolar/testtool-sdk-golang/api"
+	"github.com/OpenTestSolar/testtool-sdk-golang/model"
+	"github.com/nightlyone/lockfile"
+	"github.com/pkg/errors"
+)
+
+const (
+	MagicNumber uint32 = 0x1234ABCD
+	PipeWriter  int    = 3
+)
+
+type ReporterClient struct {
+	pipeIO       *os.File
+	lockFile     lockfile.Lockfile
+	lockFilePath string
+}
+
+func NewReporterClient() (api.Reporter, error) {
+	pipeIO := os.NewFile(uintptr(PipeWriter), "pipe")
+	lockFilePath := "/tmp/testsolar_reporter.lock"
+
+	lock, err := lockfile.New(lockFilePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create lock file")
+	}
+
+	return &ReporterClient{
+		pipeIO:       pipeIO,
+		lockFile:     lock,
+		lockFilePath: lockFilePath,
+	}, nil
+}
+
+func (r *ReporterClient) ReportLoadResult(loadResult *model.LoadResult) error {
+	return r.sendJSON(loadResult)
+}
+
+func (r *ReporterClient) ReportCaseResult(caseResult *model.TestResult) error {
+	return r.sendJSON(caseResult)
+}
+
+func (r *ReporterClient) Close() error {
+	if r.pipeIO != nil {
+		return r.pipeIO.Close()
+	}
+	return nil
+}
+
+func (r *ReporterClient) sendJSON(data interface{}) error {
+	// Acquire lock
+	err := r.lockFile.TryLock()
+	if err != nil {
+		return errors.Wrap(err, "failed to acquire lock")
+	}
+	defer r.lockFile.Unlock()
+
+	// Marshal data to JSON with custom datetime encoding
+	jsonData, err := json.Marshal(data)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal JSON")
+	}
+
+	// Write magic number, length, and JSON data to the pipe
+	if err := r.writeToPipe(MagicNumber, jsonData); err != nil {
+		return errors.Wrap(err, "failed to write to pipe")
+	}
+
+	return nil
+}
+
+func (r *ReporterClient) writeToPipe(magicNumber uint32, data []byte) error {
+	length := uint32(len(data))
+
+	// Write magic number
+	if err := binary.Write(r.pipeIO, binary.LittleEndian, magicNumber); err != nil {
+		return err
+	}
+
+	// Write length
+	if err := binary.Write(r.pipeIO, binary.LittleEndian, length); err != nil {
+		return err
+	}
+
+	// Write data
+	if _, err := r.pipeIO.Write(data); err != nil {
+		return err
+	}
+
+	// Flush the pipe if possible
+	if err := r.pipeIO.Sync(); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/client/client.go
+++ b/client/client.go
@@ -28,7 +28,7 @@ func NewReporterClient() (api.Reporter, error) {
 
 	lock, err := lockfile.New(lockFilePath)
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to create lock file")
+		return nil, errors.Wrapf(err, "failed to create lock file: %s", lockFilePath)
 	}
 
 	return &ReporterClient{
@@ -80,22 +80,22 @@ func (r *ReporterClient) writeToPipe(magicNumber uint32, data []byte) error {
 
 	// Write magic number
 	if err := binary.Write(r.pipeIO, binary.LittleEndian, magicNumber); err != nil {
-		return err
+		return errors.Wrap(err, "failed to write magic number to pipe")
 	}
 
 	// Write length
 	if err := binary.Write(r.pipeIO, binary.LittleEndian, length); err != nil {
-		return err
+		return errors.Wrap(err, "failed to write length of data to pipe")
 	}
 
 	// Write data
 	if _, err := r.pipeIO.Write(data); err != nil {
-		return err
+		return errors.Wrap(err, "failed to write data to pipe")
 	}
 
 	// Flush the pipe if possible
 	if err := r.pipeIO.Sync(); err != nil {
-		return err
+		return errors.Wrap(err, "failed to flush pipe")
 	}
 
 	return nil

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,0 +1,142 @@
+package client
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/OpenTestSolar/testtool-sdk-golang/model"
+	"github.com/google/go-cmp/cmp"
+)
+
+// TestReporter_ReportLoadResult tests the ReportLoadResult method
+func TestReporter_ReportLoadResult(t *testing.T) {
+	// Prepare test data
+	loadResult := &model.LoadResult{
+		Tests: []model.TestCase{
+			{
+				Name:       "test1",
+				Attributes: map[string]string{},
+			},
+		},
+		LoadErrors: []model.LoadError{
+			{
+				Name:    "test2",
+				Message: "load failed",
+			},
+		},
+	}
+
+	// Create a temporary file to simulate the pipe
+	tmpFile, err := os.CreateTemp("", "pipe")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Create a ReporterClient instance
+	reporter, err := NewReporterClient()
+	if err != nil {
+		t.Fatalf("Failed to create reporter: %v", err)
+	}
+	defer reporter.Close()
+
+	// Set reporter's pipeIO to the temporary file
+	reporter.(*ReporterClient).pipeIO = tmpFile
+
+	// Call ReportLoadResult method
+	err = reporter.ReportLoadResult(loadResult)
+	if err != nil {
+		t.Fatalf("ReportLoadResult failed: %v", err)
+	}
+
+	// Verify result
+	verifyPipeData[model.LoadResult](t, tmpFile, *loadResult)
+}
+
+// TestReporter_ReportCaseResult tests the ReportCaseResult method
+func TestReporter_ReportCaseResult(t *testing.T) {
+	// Prepare test data
+	caseResult := &model.TestResult{
+		Test: model.TestCase{
+			Name:       "test1",
+			Attributes: map[string]string{},
+		},
+		StartTime:  time.Now(),
+		ResultType: model.ResultTypeSucceed,
+		Message:    "test passed",
+		EndTime:    nil,
+		Steps:      nil,
+	}
+
+	// Create a temporary file to simulate the pipe
+	tmpFile, err := os.CreateTemp("", "pipe")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	// Create a Reporter instance
+	reporter, err := NewReporterClient()
+	if err != nil {
+		t.Fatalf("Failed to create reporter: %v", err)
+	}
+	defer reporter.Close()
+
+	// Set reporter's pipeIO to the temporary file
+	reporter.(*ReporterClient).pipeIO = tmpFile
+
+	// Call ReportCaseResult method
+	err = reporter.ReportCaseResult(caseResult)
+	if err != nil {
+		t.Fatalf("ReportCaseResult failed: %v", err)
+	}
+
+	// Verify result
+	verifyPipeData[model.TestResult](t, tmpFile, *caseResult)
+}
+
+// verifyPipeData reads data from the pipe file and verifies if it meets expectations
+func verifyPipeData[T any](t *testing.T, pipeFile *os.File, expected T) {
+	// Re-open the temporary file to read from the beginning
+	file, err := os.Open(pipeFile.Name())
+	if err != nil {
+		t.Fatalf("Failed to open temp file: %v", err)
+	}
+	defer file.Close()
+
+	// Read and verify magic number
+	var magicNumber uint32
+	err = binary.Read(file, binary.LittleEndian, &magicNumber)
+	if err != nil {
+		t.Fatalf("Failed to read magic number: %v", err)
+	}
+	if magicNumber != MagicNumber {
+		t.Errorf("Expected magic number %v, but got %v", MagicNumber, magicNumber)
+	}
+
+	// Read and verify data length
+	var length uint32
+	err = binary.Read(file, binary.LittleEndian, &length)
+	if err != nil {
+		t.Fatalf("Failed to read length: %v", err)
+	}
+
+	// Read and verify data
+	data := make([]byte, length)
+	_, err = file.Read(data)
+	if err != nil {
+		t.Fatalf("Failed to read data: %v", err)
+	}
+
+	var result T
+	err = json.Unmarshal(data, &result)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal data to obj: %v", err)
+	}
+	if !cmp.Equal(expected, result) {
+		t.Errorf("Expected result %+v, but got %+v", expected, result)
+	}
+}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -3,22 +3,22 @@ package client
 import (
 	"encoding/binary"
 	"encoding/json"
+	"fmt"
 	"os"
 	"testing"
 	"time"
 
 	"github.com/OpenTestSolar/testtool-sdk-golang/model"
-	"github.com/google/go-cmp/cmp"
 )
 
-// TestReporter_ReportLoadResult tests the ReportLoadResult method
-func TestReporter_ReportLoadResult(t *testing.T) {
-	// Prepare test data
-	loadResult := &model.LoadResult{
+func generateLoadResults() *model.LoadResult {
+	return &model.LoadResult{
 		Tests: []model.TestCase{
 			{
-				Name:       "test1",
-				Attributes: map[string]string{},
+				Name: "test1",
+				Attributes: map[string]string{
+					"key": "value",
+				},
 			},
 		},
 		LoadErrors: []model.LoadError{
@@ -28,6 +28,12 @@ func TestReporter_ReportLoadResult(t *testing.T) {
 			},
 		},
 	}
+}
+
+// TestReporter_ReportLoadResult tests the ReportLoadResult method
+func TestReporter_ReportLoadResult(t *testing.T) {
+	// Prepare test data
+	loadResult := generateLoadResults()
 
 	// Create a temporary file to simulate the pipe
 	tmpFile, err := os.CreateTemp("", "pipe")
@@ -53,13 +59,11 @@ func TestReporter_ReportLoadResult(t *testing.T) {
 	}
 
 	// Verify result
-	verifyPipeData[model.LoadResult](t, tmpFile, *loadResult)
+	verifyPipeData(t, tmpFile)
 }
 
-// TestReporter_ReportCaseResult tests the ReportCaseResult method
-func TestReporter_ReportCaseResult(t *testing.T) {
-	// Prepare test data
-	caseResult := &model.TestResult{
+func generateCaseResult() *model.TestResult {
+	return &model.TestResult{
 		Test: model.TestCase{
 			Name:       "test1",
 			Attributes: map[string]string{},
@@ -67,9 +71,45 @@ func TestReporter_ReportCaseResult(t *testing.T) {
 		StartTime:  time.Now(),
 		ResultType: model.ResultTypeSucceed,
 		Message:    "test passed",
-		EndTime:    nil,
-		Steps:      nil,
+		EndTime:    time.Now(),
+		Steps: []model.TestCaseStep{
+			{
+				StartTime:  time.Now(),
+				Title:      "step1",
+				ResultType: model.ResultTypeSucceed,
+				EndTime:    time.Now(),
+				Logs: []model.TestCaseLog{
+					{
+						Time:    time.Now(),
+						Level:   model.LogLevelInfo,
+						Content: "step1 passed",
+						AssertError: model.TestCaseAssertError{
+							Expect:  "expect",
+							Actual:  "actual",
+							Message: "assert failed",
+						},
+						RuntimeError: model.TestCaseRuntimeError{
+							Summary: "runtime error",
+							Detail:  "runtime error detail",
+						},
+						Attachments: []model.Attachment{
+							{
+								Name:           "attachment1",
+								Url:            "http://example.com/attachment1",
+								AttachmentType: model.AttachmentTypeFile,
+							},
+						},
+					},
+				},
+			},
+		},
 	}
+}
+
+// TestReporter_ReportCaseResult tests the ReportCaseResult method
+func TestReporter_ReportCaseResult(t *testing.T) {
+	// Prepare test data
+	caseResult := generateCaseResult()
 
 	// Create a temporary file to simulate the pipe
 	tmpFile, err := os.CreateTemp("", "pipe")
@@ -95,11 +135,93 @@ func TestReporter_ReportCaseResult(t *testing.T) {
 	}
 
 	// Verify result
-	verifyPipeData[model.TestResult](t, tmpFile, *caseResult)
+	verifyPipeData(t, tmpFile)
+}
+
+func verifyCaseResultFields(t *testing.T, result map[string]interface{}) {
+	verifyDateTimeFormat := func(obj map[string]interface{}, key string) {
+		timeStr, ok := obj[key].(string)
+		if !ok {
+			t.Fatal("time field is missing or not a string")
+		}
+		if _, err := time.Parse(model.DateTimeFormat, timeStr); err != nil {
+			t.Fatalf("time field does not match the expected format: %v", err)
+		}
+	}
+	for _, field := range []string{
+		"StartTime",
+		"EndTime",
+	} {
+		verifyDateTimeFormat(result, field)
+	}
+	steps := result["Steps"].([]interface{})
+	for _, step := range steps {
+		step := step.(map[string]interface{})
+		for _, field := range []string{
+			"StartTime",
+			"EndTime",
+		} {
+			verifyDateTimeFormat(step, field)
+		}
+		if _, ok := step["Logs"]; ok {
+			testCaseLogs := step["Logs"].([]interface{})
+			for _, testCaseLog := range testCaseLogs {
+				testCaseLog := testCaseLog.(map[string]interface{})
+				level := testCaseLog["Level"].(string)
+				if level != "INFO" {
+					t.Errorf("Incorrect log level: %s", level)
+				}
+				content := testCaseLog["Content"].(string)
+				if content != "step1 passed" {
+					t.Errorf("Incorrect log content: %s", content)
+				}
+				verifyDateTimeFormat(testCaseLog, "Time")
+			}
+		}
+	}
+	resultType := result["ResultType"].(string)
+	if resultType != "SUCCEED" {
+		t.Errorf("Incorrect result type: %s", resultType)
+	}
+	message := result["Message"].(string)
+	if message != "test passed" {
+		t.Errorf("Incorrect message: %s", message)
+	}
+}
+
+func verifyLoadResultFields(t *testing.T, result map[string]interface{}) {
+	tests := result["Tests"].([]interface{})
+	for _, test := range tests {
+		test := test.(map[string]interface{})
+		name := test["Name"].(string)
+		if name != "test1" {
+			t.Error("Incorrect test name")
+		}
+		attr := test["Attributes"].(map[string]interface{})
+		for key, value := range attr {
+			value = value.(string)
+			if key == "key" && value == "value" {
+				continue
+			}
+			t.Error("Incorrect test attribute")
+		}
+	}
+	loadErrors := result["LoadErrors"].([]interface{})
+	for _, loadError := range loadErrors {
+		loadError := loadError.(map[string]interface{})
+		name := loadError["Name"].(string)
+		if name != "test2" {
+			t.Error("Incorrect test name")
+		}
+		message := loadError["Message"].(string)
+		if message != "load failed" {
+			t.Error("Incorrect message")
+		}
+	}
 }
 
 // verifyPipeData reads data from the pipe file and verifies if it meets expectations
-func verifyPipeData[T any](t *testing.T, pipeFile *os.File, expected T) {
+func verifyPipeData(t *testing.T, pipeFile *os.File) {
 	// Re-open the temporary file to read from the beginning
 	file, err := os.Open(pipeFile.Name())
 	if err != nil {
@@ -130,13 +252,15 @@ func verifyPipeData[T any](t *testing.T, pipeFile *os.File, expected T) {
 	if err != nil {
 		t.Fatalf("Failed to read data: %v", err)
 	}
-
-	var result T
+	var result map[string]interface{}
+	fmt.Printf("Raw json string: %s\n", string(data))
 	err = json.Unmarshal(data, &result)
 	if err != nil {
 		t.Fatalf("Failed to unmarshal data to obj: %v", err)
 	}
-	if !cmp.Equal(expected, result) {
-		t.Errorf("Expected result %+v, but got %+v", expected, result)
+	if _, ok := result["ResultType"]; ok {
+		verifyCaseResultFields(t, result)
+	} else {
+		verifyLoadResultFields(t, result)
 	}
 }

--- a/example/example.go
+++ b/example/example.go
@@ -1,19 +1,3 @@
-# testtool-sdk-golang
-TestTool Golang SDK  for TestSolar
-
-## Installation
-
-Use the `go get` command to install this SDK:
-
-```bash
-go get github.com/OpenTestSolar/testtool-sdk-golang
-```
-
-## Usage Example
-
-Here is a simple usage example:
-
-```go
 package main
 
 import (
@@ -59,5 +43,3 @@ func main() {
 		fmt.Printf("Failed to close reporter: %v\n", err)
 	}
 }
-```
-

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,10 @@
+module github.com/OpenTestSolar/testtool-sdk-golang
+
+go 1.18
+
+require (
+	github.com/nightlyone/lockfile v1.0.0
+	github.com/pkg/errors v0.9.1
+)
+
+require github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,3 @@ require (
 	github.com/nightlyone/lockfile v1.0.0
 	github.com/pkg/errors v0.9.1
 )
-
-require github.com/google/go-cmp v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,6 @@
+github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
+github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
-github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/nightlyone/lockfile v1.0.0 h1:RHep2cFKK4PonZJDdEl4GmkabuhbsRMgk/k3uAmxBiA=
 github.com/nightlyone/lockfile v1.0.0/go.mod h1:rywoIealpdNse2r832aiD9jRk8ErCatROs6LzC841CI=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/model/load.go
+++ b/model/load.go
@@ -2,12 +2,12 @@ package model
 
 // LoadError represents an error that occurred during the loading process.
 type LoadError struct {
-	Name    string
-	Message string
+	Name    string `json:"Name"`
+	Message string `json:"Message"`
 }
 
 // LoadResult represents the result of a loading process, including any errors.
 type LoadResult struct {
-	Tests      []TestCase
-	LoadErrors []LoadError
+	Tests      []TestCase  `json:"Tests"`
+	LoadErrors []LoadError `json:"LoadErrors"`
 }

--- a/model/load.go
+++ b/model/load.go
@@ -2,8 +2,8 @@ package model
 
 // LoadError represents an error that occurred during the loading process.
 type LoadError struct {
-	Name    string `json:"name"`
-	Message string `json:"message"`
+	Name    string
+	Message string
 }
 
 // LoadResult represents the result of a loading process, including any errors.

--- a/model/load.go
+++ b/model/load.go
@@ -1,0 +1,13 @@
+package model
+
+// LoadError represents an error that occurred during the loading process.
+type LoadError struct {
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+// LoadResult represents the result of a loading process, including any errors.
+type LoadResult struct {
+	Tests      []TestCase
+	LoadErrors []LoadError
+}

--- a/model/result.go
+++ b/model/result.go
@@ -46,39 +46,39 @@ const (
 
 // TestCaseAssertError represents an assertion error in a test case.
 type TestCaseAssertError struct {
-	Expect  string
-	Actual  string
-	Message string
+	Expect  string `json:"Expect"`
+	Actual  string `json:"Actual"`
+	Message string `json:"Message"`
 }
 
 // TestCaseRuntimeError represents a runtime error in a test case.
 type TestCaseRuntimeError struct {
-	Summary string
-	Detail  string
+	Summary string `json:"Summary"`
+	Detail  string `json:"Detail"`
 }
 
 // Attachment represents an attachment in a test case log.
 type Attachment struct {
-	Name           string
-	Url            string
-	AttachmentType AttachmentType
+	Name           string         `json:"Name"`
+	Url            string         `json:"Url"`
+	AttachmentType AttachmentType `json:"AttachmentType"`
 }
 
 // TestCaseLog represents a log entry for a test case.
 type TestCaseLog struct {
-	Time         time.Time
-	Level        LogLevel
-	Content      string
-	AssertError  TestCaseAssertError
-	RuntimeError TestCaseRuntimeError
-	Attachments  []Attachment
+	Time         time.Time            `json:"-"`
+	Level        LogLevel             `json:"Level"`
+	Content      string               `json:"Content"`
+	AssertError  TestCaseAssertError  `json:"AssertError"`
+	RuntimeError TestCaseRuntimeError `json:"RuntimeError"`
+	Attachments  []Attachment         `json:"Attachments"`
 }
 
 // MarshalJSON implements the json.Marshaler interface for TestCaseLog.
 func (tcl TestCaseLog) MarshalJSON() ([]byte, error) {
 	type Alias TestCaseLog
 	return json.Marshal(&struct {
-		Time string
+		Time string `json:"Time"`
 		*Alias
 	}{
 		Time:  tcl.Time.UTC().Format(DateTimeFormat),
@@ -88,19 +88,19 @@ func (tcl TestCaseLog) MarshalJSON() ([]byte, error) {
 
 // TestCaseStep represents a step in a test case.
 type TestCaseStep struct {
-	StartTime  time.Time
-	Title      string
-	ResultType ResultType
-	EndTime    time.Time
-	Logs       []TestCaseLog
+	StartTime  time.Time     `json:"-"`
+	Title      string        `json:"Title"`
+	ResultType ResultType    `json:"ResultType"`
+	EndTime    time.Time     `json:"-"`
+	Logs       []TestCaseLog `json:"Logs"`
 }
 
 // MarshalJSON implements the json.Marshaler interface for TestCaseStep.
 func (tcs TestCaseStep) MarshalJSON() ([]byte, error) {
 	type Alias TestCaseStep
 	return json.Marshal(&struct {
-		StartTime string
-		EndTime   string
+		StartTime string `json:"StartTime"`
+		EndTime   string `json:"EndTime"`
 		*Alias
 	}{
 		StartTime: tcs.StartTime.UTC().Format(DateTimeFormat),
@@ -111,20 +111,20 @@ func (tcs TestCaseStep) MarshalJSON() ([]byte, error) {
 
 // TestResult represents the result of a test case.
 type TestResult struct {
-	Test       TestCase
-	StartTime  time.Time
-	ResultType ResultType
-	Message    string
-	EndTime    time.Time
-	Steps      []TestCaseStep
+	Test       TestCase       `json:"Test"`
+	StartTime  time.Time      `json:"-"`
+	ResultType ResultType     `json:"ResultType"`
+	Message    string         `json:"Message"`
+	EndTime    time.Time      `json:"-"`
+	Steps      []TestCaseStep `json:"Steps"`
 }
 
 // MarshalJSON implements the json.Marshaler interface for TestResult.
 func (tr TestResult) MarshalJSON() ([]byte, error) {
 	type Alias TestResult
 	return json.Marshal(&struct {
-		StartTime string
-		EndTime   string
+		StartTime string `json:"StartTime"`
+		EndTime   string `json:"EndTime"`
 		*Alias
 	}{
 		StartTime: tr.StartTime.UTC().Format(DateTimeFormat),

--- a/model/result.go
+++ b/model/result.go
@@ -1,8 +1,12 @@
 package model
 
 import (
+	"encoding/json"
 	"time"
 )
+
+// DateTimeFormat is the format string for JSON datetime representation.
+const DateTimeFormat = "2006-01-02T15:04:05.000Z"
 
 // ResultType is an enumeration of possible test result types.
 type ResultType string
@@ -65,9 +69,21 @@ type TestCaseLog struct {
 	Time         time.Time
 	Level        LogLevel
 	Content      string
-	AssertError  *TestCaseAssertError
-	RuntimeError *TestCaseRuntimeError
+	AssertError  TestCaseAssertError
+	RuntimeError TestCaseRuntimeError
 	Attachments  []Attachment
+}
+
+// MarshalJSON implements the json.Marshaler interface for TestCaseLog.
+func (tcl TestCaseLog) MarshalJSON() ([]byte, error) {
+	type Alias TestCaseLog
+	return json.Marshal(&struct {
+		Time string
+		*Alias
+	}{
+		Time:  tcl.Time.UTC().Format(DateTimeFormat),
+		Alias: (*Alias)(&tcl),
+	})
 }
 
 // TestCaseStep represents a step in a test case.
@@ -75,8 +91,22 @@ type TestCaseStep struct {
 	StartTime  time.Time
 	Title      string
 	ResultType ResultType
-	EndTime    *time.Time
+	EndTime    time.Time
 	Logs       []TestCaseLog
+}
+
+// MarshalJSON implements the json.Marshaler interface for TestCaseStep.
+func (tcs TestCaseStep) MarshalJSON() ([]byte, error) {
+	type Alias TestCaseStep
+	return json.Marshal(&struct {
+		StartTime string
+		EndTime   string
+		*Alias
+	}{
+		StartTime: tcs.StartTime.UTC().Format(DateTimeFormat),
+		EndTime:   tcs.EndTime.UTC().Format(DateTimeFormat),
+		Alias:     (*Alias)(&tcs),
+	})
 }
 
 // TestResult represents the result of a test case.
@@ -85,6 +115,20 @@ type TestResult struct {
 	StartTime  time.Time
 	ResultType ResultType
 	Message    string
-	EndTime    *time.Time
+	EndTime    time.Time
 	Steps      []TestCaseStep
+}
+
+// MarshalJSON implements the json.Marshaler interface for TestResult.
+func (tr TestResult) MarshalJSON() ([]byte, error) {
+	type Alias TestResult
+	return json.Marshal(&struct {
+		StartTime string
+		EndTime   string
+		*Alias
+	}{
+		StartTime: tr.StartTime.UTC().Format(DateTimeFormat),
+		EndTime:   tr.EndTime.UTC().Format(DateTimeFormat),
+		Alias:     (*Alias)(&tr),
+	})
 }

--- a/model/result.go
+++ b/model/result.go
@@ -1,0 +1,90 @@
+package model
+
+import (
+	"time"
+)
+
+// ResultType is an enumeration of possible test result types.
+type ResultType string
+
+// Enum values for ResultType
+const (
+	ResultTypeUnknown    ResultType = "UNKNOWN"
+	ResultTypeSucceed    ResultType = "SUCCEED"
+	ResultTypeFailed     ResultType = "FAILED"
+	ResultTypeLoadFailed ResultType = "LOAD_FAILED"
+	ResultTypeIgnored    ResultType = "IGNORED"
+	ResultTypeRunning    ResultType = "RUNNING"
+	ResultTypeWaiting    ResultType = "WAITING"
+)
+
+// LogLevel is an enumeration of possible log levels.
+type LogLevel string
+
+// Enum values for LogLevel
+const (
+	LogLevelTrace LogLevel = "VERBOSE"
+	LogLevelDebug LogLevel = "DEBUG"
+	LogLevelInfo  LogLevel = "INFO"
+	LogLevelWarn  LogLevel = "WARNNING"
+	LogLevelError LogLevel = "ERROR"
+)
+
+// AttachmentType is an enumeration of possible attachment types.
+type AttachmentType string
+
+// Enum values for AttachmentType
+const (
+	AttachmentTypeFile   AttachmentType = "FILE"
+	AttachmentTypeURL    AttachmentType = "URL"
+	AttachmentTypeIFrame AttachmentType = "IFRAME"
+)
+
+// TestCaseAssertError represents an assertion error in a test case.
+type TestCaseAssertError struct {
+	Expect  string
+	Actual  string
+	Message string
+}
+
+// TestCaseRuntimeError represents a runtime error in a test case.
+type TestCaseRuntimeError struct {
+	Summary string
+	Detail  string
+}
+
+// Attachment represents an attachment in a test case log.
+type Attachment struct {
+	Name           string
+	Url            string
+	AttachmentType AttachmentType
+}
+
+// TestCaseLog represents a log entry for a test case.
+type TestCaseLog struct {
+	Time         time.Time
+	Level        LogLevel
+	Content      string
+	AssertError  *TestCaseAssertError
+	RuntimeError *TestCaseRuntimeError
+	Attachments  []Attachment
+}
+
+// TestCaseStep represents a step in a test case.
+type TestCaseStep struct {
+	StartTime  time.Time
+	Title      string
+	ResultType ResultType
+	EndTime    *time.Time
+	Logs       []TestCaseLog
+}
+
+// TestResult represents the result of a test case.
+type TestResult struct {
+	Test       TestCase
+	StartTime  time.Time
+	ResultType ResultType
+	Message    string
+	EndTime    *time.Time
+	Steps      []TestCaseStep
+}

--- a/model/testcase.go
+++ b/model/testcase.go
@@ -2,6 +2,6 @@ package model
 
 // TestCase represents a test case with a name and a set of attributes.
 type TestCase struct {
-	Name       string
-	Attributes map[string]string
+	Name       string            `json:"Name"`
+	Attributes map[string]string `json:"Attributes"`
 }

--- a/model/testcase.go
+++ b/model/testcase.go
@@ -1,0 +1,7 @@
+package model
+
+// TestCase represents a test case with a name and a set of attributes.
+type TestCase struct {
+	Name       string
+	Attributes map[string]string
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+COVERAGE_THRESHOLD=70
+
+go test -coverprofile=coverage.out ./...
+
+COVERAGE=$(go tool cover -func=coverage.out | awk '/total:/ {print substr($3, 1, length($3)-1)}')
+
+echo "Total test coverage: ${COVERAGE}%"
+
+if (( $(echo "$COVERAGE < $COVERAGE_THRESHOLD" | bc -l) )); then
+  echo "Coverage below threshold: ${COVERAGE_THRESHOLD}%"
+  exit 1
+else
+  echo "Coverage meets the threshold: ${COVERAGE_THRESHOLD}%"
+fi


### PR DESCRIPTION
This commit introduces the ReportLoadResult/ReportCaseResult/Close interface to the SDK, allowing the client to report loaded case and case results after execution.